### PR TITLE
Do not broadcast link success

### DIFF
--- a/components/zehnder/zehnder.cpp
+++ b/components/zehnder/zehnder.cpp
@@ -306,7 +306,7 @@ void ZehnderRF::rfHandleReceived(const uint8_t *const pData, const uint8_t dataL
             (void) memset(this->_txFrame, 0, FAN_FRAMESIZE);  // Clear frame data
 
             pTxFrame->rx_type = FAN_TYPE_MAIN_UNIT;  // Set type to main unit
-            pTxFrame->rx_id = 0x00;  // Broadcast
+            pTxFrame->rx_id = pResponse->tx_id; // Set ID to the ID of the main unit
             pTxFrame->tx_type = this->config_.fan_my_device_type;
             pTxFrame->tx_id = this->config_.fan_my_device_id;
             pTxFrame->ttl = FAN_TTL;


### PR DESCRIPTION
Link success should not be a broadcast message. In my case, this prevented successful pairing. Your prior change to change `rx_id` to broadcast is correct when it concerns advertising the speed change (otherwise my CO2 sensor indeed overrules the change quickly), but it does not make sense (at least not to me) during the discovery/pairing phase.